### PR TITLE
Fix camelizeObject error

### DIFF
--- a/src/Response/JSON.php
+++ b/src/Response/JSON.php
@@ -2,9 +2,9 @@
 
 namespace TeamWorkPm\Response;
 
-use ArrayObject;
+use \ArrayObject;
 use TeamWorkPm\Exception;
-use TeamWorkPm\Helper\Str;
+use \TeamWorkPm\Helper\Str;
 
 class JSON extends Model
 {
@@ -127,7 +127,7 @@ class JSON extends Model
      *
      * @return ArrayObject
      */
-    protected static function camelizeObject(array $source)
+    protected static function camelizeObject($source)
     {
         $destination = new ArrayObject([], ArrayObject::ARRAY_AS_PROPS);
         foreach ($source as $key => $value) {

--- a/src/Response/JSON.php
+++ b/src/Response/JSON.php
@@ -2,9 +2,9 @@
 
 namespace TeamWorkPm\Response;
 
-use \ArrayObject;
+use ArrayObject;
 use TeamWorkPm\Exception;
-use \TeamWorkPm\Helper\Str;
+use TeamWorkPm\Helper\Str;
 
 class JSON extends Model
 {


### PR DESCRIPTION
Constantly getting "Uncaught TypeError: Argument 1 passed to TeamWorkPm\Response\JSON::camelizeObject() must be of the type array, object given".

Even when testing by using the provided example scripts.

Removing the 'array' type hint from the camelizeObject method fixes this error.