### PR TITLE
Adding Classes for the Portfolio Board endpoints

### DIFF
--- a/src/Portfolio/Board.php
+++ b/src/Portfolio/Board.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace TeamWorkPm\Portfolio;
+
+use TeamWorkPm\Model;
+
+class Board extends Model
+{
+    public function init()
+    {
+        $this->parent = 'board';
+        $this->action = 'portfolio/boards';
+
+        $this->fields = [
+            'canEdit' => [
+                'required' => false,
+                'attributes' => ['type' => 'boolean'],
+            ],
+
+            'name' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'displayOrder' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'description' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'deletedDate' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'id' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'dateCreated' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'color' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'deleted' => [
+                'required' => false,
+                'attributes' => ['type' => 'boolean'],
+            ],
+        ];
+    }
+
+    /**
+     * Get all the Portfolio Boards
+     * GET /portfolio/boards
+     *
+     * @return \TeamWorkPm\Response\Model
+     * @throws \TeamWorkPm\Exception
+     */
+    public function getAll()
+    {
+        return $this->rest->get("$this->action");
+    }
+}

--- a/src/Portfolio/Card.php
+++ b/src/Portfolio/Card.php
@@ -56,8 +56,6 @@ class Card extends Model
      */
     public function getAllForColumn($columnId)
     {
-        // Doesnt work
-
         $columnId = (int) $columnId;
         if ($columnId <= 0) {
             throw new Exception('Invalid param columnId');

--- a/src/Portfolio/Card.php
+++ b/src/Portfolio/Card.php
@@ -49,7 +49,7 @@ class Card extends Model
      * Get all the Columns for a Portfolio Column
      * GET /portfolio/columns/{columnId}/cards
      *
-     * @param integer $columnId
+     * @param int $columnId
      *
      * @return \TeamWorkPm\Response\Model
      * @throws \TeamWorkPm\Exception

--- a/src/Portfolio/Card.php
+++ b/src/Portfolio/Card.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace TeamWorkPm\Portfolio;
+
+use TeamWorkPm\Exception;
+use TeamWorkPm\Model;
+
+class Card extends Model
+{
+    public function init()
+    {
+        $this->parent = 'card';
+        $this->action = 'portfolio/cards';
+
+        $this->fields = [
+            'projectId' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            // These are only used by the update method
+            'cardId' => [
+                'required' => false,
+                'sibling' => true,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'columnId' => [
+                'required' => false,
+                'sibling' => true, // Dont nest under 'Card'
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'oldColumnId' => [
+                'required' => false,
+                'sibling' => true, // Dont nest under 'Card'
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'positionAfterId' => [
+                'required' => false,
+                'sibling' => true, // Dont nest under 'Card'
+                'attributes' => ['type' => 'integer'],
+            ],
+        ];
+    }
+
+    /**
+     * Get all the Columns for a Portfolio Column
+     * GET /portfolio/columns/{columnId}/cards
+     *
+     * @param integer $columnId
+     *
+     * @return \TeamWorkPm\Response\Model
+     * @throws \TeamWorkPm\Exception
+     */
+    public function getAllForColumn($columnId)
+    {
+        // Doesnt work
+
+        $columnId = (int) $columnId;
+        if ($columnId <= 0) {
+            throw new Exception('Invalid param columnId');
+        }
+
+        return $this->rest->get("portfolio/columns/$columnId/cards");
+    }
+
+    /**
+     * Adds a project to the given board
+     *
+     * @param array $data
+     *
+     * @return int
+     */
+    public function insert(array $data)
+    {
+        $columnId = empty($data['columnId']) ? 0 : (int) $data['columnId'];
+        if ($columnId <= 0) {
+            throw new Exception('Required field columnId');
+        }
+        unset($data['columnId']);
+
+        if (empty($data['projectId'])) {
+            throw new Exception('Required field projectId');
+        }
+
+        return $this->rest->post("portfolio/columns/$columnId/cards", $data);
+    }
+
+    /**
+     * Moves the given card from one board to another
+     *
+     * @param array $data
+     *
+     * @return bool
+     * @throws \TeamWorkPm\Exception
+     */
+    public function update(array $data)
+    {
+        $cardId = empty($data['id']) ? 0: (int) $data['id'];
+        if ($cardId <= 0) {
+            throw new Exception('Required field id');
+        }
+        $data['cardId'] = $data['id'];
+        unset($data['id']);
+
+        if (empty($data['columnId'])) {
+            throw new Exception('Required field columnId');
+        }
+
+        if (empty($data['oldColumnId'])) {
+            throw new Exception('Required field oldColumnId');
+        }
+
+        return $this->rest->put("$this->action/$cardId/move", $data);
+    }
+
+}

--- a/src/Portfolio/Column.php
+++ b/src/Portfolio/Column.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace TeamWorkPm\Portfolio;
+
+use TeamWorkPm\Exception;
+use TeamWorkPm\Model;
+
+class Column extends Model
+{
+    public function init()
+    {
+        $this->parent = 'column';
+        $this->action = 'portfolio/columns';
+
+        $this->fields = [
+            'name' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'displayOrder' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'sortOrder' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'deletedDate' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'dateUpdated' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'hasTriggers' => [
+                'required' => false,
+                'attributes' => ['type' => 'boolean'],
+            ],
+
+            'sort' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'canEdit' => [
+                'required' => false,
+                'attributes' => ['type' => 'boolean'],
+            ],
+
+            'id' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'dateCreated' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'color' => [
+                'required' => false,
+                'attributes' => ['type' => 'string'],
+            ],
+
+            'deleted' => [
+                'required' => false,
+                'attributes' => ['type' => 'boolean'],
+            ],
+        ];
+    }
+
+    /**
+     * Get all the Columns for a Portfolio Board
+     * GET /portfolio/boards/{boardId}/columns
+     *
+     * @param integer $boardId
+     *
+     * @return \TeamWorkPm\Response\Model
+     * @throws \TeamWorkPm\Exception
+     */
+    public function getAll($boardId)
+    {
+        $boardId = (int) $boardId;
+        if ($boardId <= 0) {
+            throw new Exception('Invalid param boardId');
+        }
+
+        return $this->rest->get("portfolio/boards/$boardId/columns");
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return int
+     */
+    public function insert(array $data)
+    {
+        $boardId = empty($data['board_id']) ? 0 : (int) $data['board_id'];
+        if ($boardId <= 0) {
+            throw new Exception('Required field board_id');
+        }
+        unset($data['board_id']);
+
+        return $this->rest->post("portfolio/boards/$boardId/columns", $data);
+    }
+}

--- a/src/Portfolio/Column.php
+++ b/src/Portfolio/Column.php
@@ -79,7 +79,7 @@ class Column extends Model
      * Get all the Columns for a Portfolio Board
      * GET /portfolio/boards/{boardId}/columns
      *
-     * @param integer $boardId
+     * @param int $boardId
      *
      * @return \TeamWorkPm\Response\Model
      * @throws \TeamWorkPm\Exception

--- a/src/Portfolio/Column.php
+++ b/src/Portfolio/Column.php
@@ -84,7 +84,7 @@ class Column extends Model
      * @return \TeamWorkPm\Response\Model
      * @throws \TeamWorkPm\Exception
      */
-    public function getAll($boardId)
+    public function getAllForBoard($boardId)
     {
         $boardId = (int) $boardId;
         if ($boardId <= 0) {

--- a/src/Response/JSON.php
+++ b/src/Response/JSON.php
@@ -74,6 +74,11 @@ class JSON extends Model
                             preg_match('!projects/(\d+)/notebooks!', $headers['X-Action'])
                         ) {
                             $source = [];
+                        } elseif (
+                            isset($source->cards) &&
+                            preg_match('!portfolio/columns/(\d+)/cards!', $headers['X-Action'])
+                        ) {
+                            $source = $source->cards;
                         } else {
                             $source = current($source);
                         }

--- a/tests/Portfolio/BoardTest.php
+++ b/tests/Portfolio/BoardTest.php
@@ -5,7 +5,7 @@ class BoardTest extends TestCase
     /** @var \TeamWorkPm\Portfolio\Board */
     private $model;
 
-    /** @var integer */
+    /** @var int */
     private $id;
 
     public function setUp()

--- a/tests/Portfolio/BoardTest.php
+++ b/tests/Portfolio/BoardTest.php
@@ -117,8 +117,8 @@ class BoardTest extends TestCase
         return [
             [
                 [
-                    "name" => "test board",
-                    "color" => "#cccccc",
+                    'name' => 'test board',
+                    'color' => '#cccccc'
                 ]
             ]
         ];

--- a/tests/Portfolio/BoardTest.php
+++ b/tests/Portfolio/BoardTest.php
@@ -1,0 +1,126 @@
+<?php
+
+class BoardTest extends TestCase
+{
+    /** @var \TeamWorkPm\Portfolio\Board */
+    private $model;
+
+    /** @var integer */
+    private $id;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->model = TeamWorkPm\Factory::build('portfolio/board');
+        $this->id = get_first_portfolio_board_id();
+    }
+
+    /**
+     * @param $data
+     *
+     * @dataProvider provider
+     * @test
+     */
+    public function insert($data)
+    {
+        try {
+            $id = $this->model->save($data);
+            $this->assertGreaterThan(0, $id);
+
+            $portfolioBoard = $this->model->get($id);
+
+            // If the name is already taken, TW adds a number suffix
+            $this->assertStringStartsWith($data['name'], $portfolioBoard->name);
+
+            $this->assertEquals($data['color'], $portfolioBoard->color);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @param $data
+     *
+     * @dataProvider provider
+     * @test
+     */
+    public function update($data)
+    {
+        try {
+            $data['id'] = $this->id;
+            $data['color'] = '#ffffff';
+
+            $this->assertTrue($this->model->save($data));
+
+            $portfolioBoard = $this->model->get($this->id);
+            $this->assertEquals($data['color'], $portfolioBoard->color);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function get()
+    {
+        try {
+            $portfolioBoard = $this->model->get($this->id);
+            $this->assertEquals($this->id, $portfolioBoard->id);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function getAll()
+    {
+        try {
+            $portfolioBoards = $this->model->getAll();
+
+            $this->assertEquals($this->id, $portfolioBoards[0]->id);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function deleteInvalidId()
+    {
+        $this->model->delete(0);
+    }
+
+    /**
+     * @test
+     */
+    public function delete()
+    {
+        try {
+            $this->assertTrue($this->model->delete($this->id));
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * Data Provider
+     *
+     * @return array
+     */
+    public function provider()
+    {
+        return [
+            [
+                [
+                    "name" => "test board",
+                    "color" => "#cccccc",
+                ]
+            ]
+        ];
+    }
+}

--- a/tests/Portfolio/CardTest.php
+++ b/tests/Portfolio/CardTest.php
@@ -5,16 +5,16 @@ class CardTest extends TestCase
     /** @var \TeamWorkPm\Portfolio\Card */
     private $model;
 
-    /** @var integer */
+    /** @var int */
     private $projectId;
 
-    /** @var integer */
+    /** @var int */
     private $boardId;
 
-    /** @var integer */
+    /** @var int */
     private $columnId;
 
-    /** @var integer */
+    /** @var int */
     private $id;
 
     public function setUp()

--- a/tests/Portfolio/CardTest.php
+++ b/tests/Portfolio/CardTest.php
@@ -1,0 +1,184 @@
+<?php
+
+class CardTest extends TestCase
+{
+    /** @var \TeamWorkPm\Portfolio\Card */
+    private $model;
+
+    /** @var integer */
+    private $projectId;
+
+    /** @var integer */
+    private $boardId;
+
+    /** @var integer */
+    private $columnId;
+
+    /** @var integer */
+    private $id;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->model = TeamWorkPm\Factory::build('portfolio/card');
+        $this->projectId = get_first_project_id();
+        $this->boardId = get_first_portfolio_board_id();
+        $this->columnId = get_first_portfolio_board_column_id($this->boardId);
+        $this->id = get_first_portfolio_card_id($this->columnId);
+    }
+
+    /**
+     * @test
+     */
+    public function insert()
+    {
+        try {
+            $data['columnId'] = $this->columnId;
+            $data['projectId'] = $this->projectId;
+
+            $this->assertTrue($this->model->save($data));
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->assertEquals('Already exists', $e->getMessage());
+        }
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function insertInvalidColumnId()
+    {
+        $data['columnId'] = 0;
+        $data['projectId'] = $this->projectId;
+
+        $this->model->save($data);
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function insertInvalidProjectId()
+    {
+        $data['columnId'] = $this->columnId;
+        $data['projectId'] = 0;
+
+        $this->model->save($data);
+    }
+
+    /**
+     * @test
+     */
+    public function update()
+    {
+        try {
+            $data['id'] = $this->id;
+            $data['oldColumnId'] = $this->columnId;
+            $data['columnId'] = $this->columnId;
+
+            $this->assertTrue($this->model->save($data));
+
+            $portfolioCard = $this->model->get($this->id);
+
+            $this->assertEquals($data['columnId'], $portfolioCard->columnId);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function updateInvalidId()
+    {
+        $data['id'] = 0;
+        $data['oldColumnId'] = $this->columnId;
+        $data['columnId'] = $this->columnId;
+
+        $this->model->save($data);
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function updateInvalidColumnId()
+    {
+        $data['id'] = $this->id;
+        $data['oldColumnId'] = 0;
+        $data['columnId'] = $this->columnId;
+
+        $this->model->save($data);
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function updateInvalidOldColumnId()
+    {
+        $data['id'] = $this->id;
+        $data['oldColumnId'] = $this->columnId;
+        $data['columnId'] = 0;
+
+        $this->model->save($data);
+    }
+
+    /**
+     * @test
+     */
+    public function get()
+    {
+        try {
+            $portfolioCard = $this->model->get($this->id);
+            $this->assertEquals($this->id, $portfolioCard->id);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function getAllForColumn()
+    {
+        try {
+            $portfolioCards = $this->model->getAllForColumn($this->columnId);
+
+            $this->assertEquals($this->id, $portfolioCards[0]->id);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function getAllForColumnInvalidId()
+    {
+        $this->model->getAllForColumn(0);
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function deleteInvalidId()
+    {
+        $this->model->delete(0);
+    }
+
+    /**
+     * @test
+     */
+    public function delete()
+    {
+        try {
+            $this->assertTrue($this->model->delete($this->id));
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+}

--- a/tests/Portfolio/ColumnTest.php
+++ b/tests/Portfolio/ColumnTest.php
@@ -1,0 +1,141 @@
+<?php
+
+class ColumnTest extends TestCase
+{
+    /** @var \TeamWorkPm\Portfolio\Column */
+    private $model;
+
+    /** @var integer */
+    private $boardId;
+
+    /** @var integer */
+    private $id;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->model = TeamWorkPm\Factory::build('portfolio/column');
+        $this->boardId = get_first_portfolio_board_id();
+        $this->id = get_first_portfolio_board_column_id($this->boardId);
+    }
+
+    /**
+     * @param $data
+     *
+     * @dataProvider provider
+     * @test
+     */
+    public function insert($data)
+    {
+        try {
+            $data['board_id'] = $this->boardId;
+
+            $id = $this->model->save($data);
+            $this->assertGreaterThan(0, $id);
+
+            $portfolioColumn = $this->model->get($id);
+
+            // If the name is already taken, TW adds a number suffix
+            $this->assertStringStartsWith($data['name'], $portfolioColumn->name);
+
+            $this->assertEquals($data['color'], $portfolioColumn->color);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @param $data
+     *
+     * @dataProvider provider
+     * @test
+     */
+    public function update($data)
+    {
+        try {
+            $data['id'] = $this->id;
+            $data['color'] = '#ffffff';
+
+            $this->assertTrue($this->model->save($data));
+
+            $portfolioColumn = $this->model->get($this->id);
+            $this->assertEquals($data['color'], $portfolioColumn->color);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function get()
+    {
+        try {
+            $portfolioColumn = $this->model->get($this->id);
+            $this->assertEquals($this->id, $portfolioColumn->id);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function getAll()
+    {
+        try {
+            $portfolioColumns = $this->model->getAll($this->boardId);
+
+            $this->assertEquals($this->id, $portfolioColumns[0]->id);
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function getAllInvalidId()
+    {
+        $this->model->getAll(0);
+    }
+
+    /**
+     * @expectedException \TeamWorkPm\Exception
+     * @test
+     */
+    public function deleteInvalidId()
+    {
+        $this->model->delete(0);
+    }
+
+    /**
+     * @test
+     */
+    public function delete()
+    {
+        try {
+            $this->assertTrue($this->model->delete($this->id));
+        } catch (\TeamWorkPm\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    /**
+     * Data Provider
+     *
+     * @return array
+     */
+    public function provider()
+    {
+        return [
+            [
+                [
+                    "name" => "test column",
+                    "color" => "#eeeeee",
+                ]
+            ]
+        ];
+    }
+}

--- a/tests/Portfolio/ColumnTest.php
+++ b/tests/Portfolio/ColumnTest.php
@@ -5,10 +5,10 @@ class ColumnTest extends TestCase
     /** @var \TeamWorkPm\Portfolio\Column */
     private $model;
 
-    /** @var integer */
+    /** @var int */
     private $boardId;
 
-    /** @var integer */
+    /** @var int */
     private $id;
 
     public function setUp()

--- a/tests/Portfolio/ColumnTest.php
+++ b/tests/Portfolio/ColumnTest.php
@@ -81,10 +81,10 @@ class ColumnTest extends TestCase
     /**
      * @test
      */
-    public function getAll()
+    public function getAllForBoard()
     {
         try {
-            $portfolioColumns = $this->model->getAll($this->boardId);
+            $portfolioColumns = $this->model->getAllForBoard($this->boardId);
 
             $this->assertEquals($this->id, $portfolioColumns[0]->id);
         } catch (\TeamWorkPm\Exception $e) {
@@ -96,9 +96,9 @@ class ColumnTest extends TestCase
      * @expectedException \TeamWorkPm\Exception
      * @test
      */
-    public function getAllInvalidId()
+    public function getAllForBoardInvalidId()
     {
-        $this->model->getAll(0);
+        $this->model->getAllForBoard(0);
     }
 
     /**

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -336,3 +336,23 @@ function get_first_portfolio_board_column_id($boardId)
     }
     return (int) $id;
 }
+
+/**
+ * Grab the ID of the first card in the given column
+ *
+ * @param integer $columnId
+ *
+ * @return int
+ */
+function get_first_portfolio_card_id($columnId)
+{
+    static $id = null;
+    if ($id === null) {
+        $portfolioCard = TeamWorkPm\Factory::build('portfolio/card');
+        foreach($portfolioCard->getAllForColumn($columnId) as $c) {
+            $id = $c->id;
+            break;
+        }
+    }
+    return (int) $id;
+}

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -320,7 +320,7 @@ function get_first_portfolio_board_id()
 /**
  * Grab the ID of the first portfolio board column id
  *
- * @param integer $boardId
+ * @param int $boardId
  *
  * @return int
  */
@@ -340,7 +340,7 @@ function get_first_portfolio_board_column_id($boardId)
 /**
  * Grab the ID of the first card in the given column
  *
- * @param integer $columnId
+ * @param int $columnId
  *
  * @return int
  */

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -316,3 +316,23 @@ function get_first_portfolio_board_id()
     }
     return (int) $id;
 }
+
+/**
+ * Grab the ID of the first portfolio board column id
+ *
+ * @param integer $boardId
+ *
+ * @return int
+ */
+function get_first_portfolio_board_column_id($boardId)
+{
+    static $id = null;
+    if ($id === null) {
+        $portfolioColumn = TeamWorkPm\Factory::build('portfolio/column');
+        foreach($portfolioColumn->getAll($boardId) as $c) {
+            $id = $c->id;
+            break;
+        }
+    }
+    return (int) $id;
+}

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -329,7 +329,7 @@ function get_first_portfolio_board_column_id($boardId)
     static $id = null;
     if ($id === null) {
         $portfolioColumn = TeamWorkPm\Factory::build('portfolio/column');
-        foreach($portfolioColumn->getAll($boardId) as $c) {
+        foreach($portfolioColumn->getAllForBoard($boardId) as $c) {
             $id = $c->id;
             break;
         }

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -298,3 +298,21 @@ function get_first_notebook_id($project_id)
     }
     return (int) $id;
 }
+
+/**
+ * Grab the ID of the first portfolio board
+ *
+ * @return int
+ */
+function get_first_portfolio_board_id()
+{
+    static $id = null;
+    if ($id === null) {
+        $portfolioBoard = TeamWorkPm\Factory::build('portfolio/board');
+        foreach($portfolioBoard->getAll() as $b) {
+            $id = $b->id;
+            break;
+        }
+    }
+    return (int) $id;
+}


### PR DESCRIPTION
Added the classes for the Portfolio Board endpoints:
https://developer.teamwork.com/projects/portfolio-boards/boards-in-portfolio-view

There are insert/update/delete/get methods for all classes, even though they are not on the API documentation (I've let teamwork know about this), but they do work.

**Portfolio\Board**
- **getAll** /portfolio/boards/ - returns all the portfolio boards
- **get** /portfolio/boards/{boardId} - returns the specific board
- **insert** /portfolio/boards - creates a new board
- **update**  /portfolio/boards/{boardId} - updates the given board
- **delete** /portfolio/boards/{boardId} - deletes the given board

**Portfolio\Column**
- **getAllForBoard** /portfolio/boards/{boardId}/columns - returns all the columns for the given board
- **get** /portfolio/columns/{icolumnId} - returns the specific column
- **insert** /portfolio/boards/{boardId}/columns - adds a column to the given board
- **update**  /portfolio/columns/{columnId} - updates the given column
- **delete** /portfolio/columns/{columnId} - deletes the given column

**Portfolio\Card**
- **getAllForColumn** /portfolio/columns/{columnId}/cards - returns all the cards for the given column
- **get** /portfolio/cards/{cardId} - returns the specific card
- **insert** /portfolio/columns/{columnId}/cards - Adds a project to the given board (thus creating a card)
- **update** /portfolio/cards/{cardId}/move - Used to move a card from one column to another
- **delete** /portfolio/cards/{cardId} - deletes the given card (removes the project from the column)