### PR TITLE
throw catchable exception instead of exit in JSON response

### DIFF
--- a/src/Response/JSON.php
+++ b/src/Response/JSON.php
@@ -30,9 +30,9 @@ class JSON extends Model
                 $headers['Status'] === 400
             )) {
                 throw new Exception([
-                    'Message'=> $errors,
-                    'Response'=> $data,
-                    'Headers'=> $headers
+                    'Message' => $errors,
+                    'Response' => $data,
+                    'Headers' => $headers
                 ]);
             }
             if ($headers['Status'] === 201 || $headers['Status'] === 200) {

--- a/src/Response/JSON.php
+++ b/src/Response/JSON.php
@@ -29,8 +29,11 @@ class JSON extends Model
                 $headers['Status'] === 422 ||
                 $headers['Status'] === 400
             )) {
-                print_r($headers);
-                exit;
+                throw new Exception([
+                    'Message'=> $errors,
+                    'Response'=> $data,
+                    'Headers'=> $headers
+                ]);
             }
             if ($headers['Status'] === 201 || $headers['Status'] === 200) {
                 switch ($headers['Method']) {


### PR DESCRIPTION
Hi,
it would be awesome if the JSON response throws an exception on other response status codes instead of exit because then you can catch it and proceed with code execution.

Thanks