### PR TITLE
Prevent "Warning: Invalid argument supplied for foreach() in [...]\ve…

### DIFF
--- a/src/Response/JSON.php
+++ b/src/Response/JSON.php
@@ -139,6 +139,10 @@ class JSON extends Model
      */
     protected static function camelizeObject($source)
     {
+        if (!$source) {
+            return;
+        }
+
         $destination = new ArrayObject([], ArrayObject::ARRAY_AS_PROPS);
         foreach ($source as $key => $value) {
             if (ctype_upper($key)) {

--- a/src/Response/JSON.php
+++ b/src/Response/JSON.php
@@ -100,7 +100,7 @@ class JSON extends Model
                         $this->headers = $headers;
                         $this->string = json_encode($source);
 
-                        $this->data   = self::camelizeObject($source);
+                        $this->data   = is_object($source) ? self::camelizeObject($source) : $source;
 
                         if (!empty($this->data->id)) {
                             $this->data->id = (int) $this->data->id;
@@ -139,8 +139,8 @@ class JSON extends Model
      */
     protected static function camelizeObject($source)
     {
-        if (!$source) {
-            return;
+        if (!is_object($source) && !is_array($source)) {
+            return $source;
         }
 
         $destination = new ArrayObject([], ArrayObject::ARRAY_AS_PROPS);


### PR DESCRIPTION
Prevent "Warning: Invalid argument supplied for foreach() in [...]\vendor\myabakus\teamworkpm\src\Response\JSON.php on line 143" warnings if the $value for the self::camelizeObject($value); line is NULL.