### PR TITLE
Fix php notice for array

### DIFF
--- a/src/Rest.php
+++ b/src/Rest.php
@@ -69,10 +69,13 @@ final class Rest
             $status      = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
             $headers     = $this->parseHeaders(substr($data, 0, $header_size));
-            if ($status === 400 &&
-                                (int) $headers['X-RateLimit-Remaining'] === 0) {
+            if (
+              $status === 400 &&
+              (int) $headers['x-ratelimit-remaining'] === 0) {
                 $i ++;
-                sleep(10);
+                $reset = $headers['x-ratelimit-reset'];
+                echo "Rate limit hit. Sleeping for: " . $reset . PHP_EOL;
+                sleep($reset);
             } else {
                 break;
             }

--- a/src/Rest.php
+++ b/src/Rest.php
@@ -71,10 +71,10 @@ final class Rest
             $headers     = $this->parseHeaders(substr($data, 0, $header_size));
             if (
               $status === 400 &&
-              (int) $headers['x-ratelimit-remaining'] === 0) {
+              (int) $headers['x-ratelimit-remaining'] === 0
+            ) {
                 $i ++;
                 $reset = $headers['x-ratelimit-reset'];
-                echo "Rate limit hit. Sleeping for: " . $reset . PHP_EOL;
                 sleep($reset);
             } else {
                 break;


### PR DESCRIPTION
Also make sleep time dependent on the API specifics not hard-coded to a value.

Fixes #48 

